### PR TITLE
Fix/default to registry file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (e.g., v0.0.14)'
+        description: 'Version to release (e.g., v0.0.15)'
         required: true
 
 permissions: {}  # Set default permissions to none

--- a/TODO.md
+++ b/TODO.md
@@ -5,19 +5,12 @@
 - Phase 0 (Configuration) should be completed before Phase 3.5 registry handling
 - Phase 2 (Flag Consistency) should be completed before Phase 3.5 file naming standardization
 - Phase 3 (Output Behavior) should be completed before implementing strict mode in Phase 3.5
-
 ## Phase 0: Configuration Setup (P0: Critical Usability) [COMPLETED]
-
 ## Phase 1: Flag Cleanup (P0: User Experience Enhancements) [COMPLETED]
-
 ## Phase 2: Flag Consistency and Defaults (P0: User Experience Enhancements) [COMPLETED]
-
 ## Phase 3: Output File Behavior Standardization (P0: User Experience Enhancements) [COMPLETED]
-
 ## Phase 3.5: Streamlined Workflow Implementation (P1: User Experience Enhancements) [COMPLETED]
-
 ## Testing Strategy for CLI Enhancements (Completed Phases Summarized) [COMPLETED]
-
 ## Phase 4: Documentation Updates (P0: User Experience Enhancements) [COMPLETED]
 
 ### Implementation Notes [COMPLETED]
@@ -68,170 +61,107 @@
 
 ##END REMINDER On the Implementation Process:
 
-## Phase 5: Remove Legacy Registry Format (P1: Technical Debt Reduction) [COMPLETED]
-- Successfully removed support for the legacy key-value registry format (`map[string]string`) and standardized on the structured format (`registry.Config`).
+#### Phase 6: Test Framework Overhaul
+- **Goal:** Transition integration tests away from requiring a live Kubernetes cluster, improving test speed, reliability, and portability by adopting a layered testing approach.
+- **P0: Critical Test Infrastructure Improvement**
 
-## Phase 6: Remove IRR_DEBUG Support [COMPLETED]
-- Eliminated the redundant legacy `IRR_DEBUG` environment variable. `LOG_LEVEL` is now the sole control for log verbosity.
+##### Phase 6.1: Mock Helm Interaction Layer (Unit/Component Tests)
+  - **Goal:** Test `irr`'s core logic (value traversal, image detection, override generation) and command-layer decision-making (e.g., differentiating standalone chart-path mode from plugin/release-name mode) in complete isolation from external Helm and Kubernetes dependencies. This provides the fastest feedback loop for core algorithm and command logic correctness.
+  - **Scope:**
+    - Unit tests and component-level integration tests that verify specific functions and modules within `irr` itself (e.g., `pkg/analyzer`, `pkg/generator`, `pkg/helm`, and especially the `cmd/irr` command implementations).
+    - Enable testing of how `irr` sources its initial data (chart values, metadata) depending on the execution mode (e.g., from local files vs. Helm release).
+  - **Design Rationale & References:**
+    - **Need for Abstraction:** As highlighted in `docs/DEVELOPMENT.MD` (Sections 6.1, 7.1, 7.2) and `docs/PLUGIN-SPECIFIC.MD` (Sections 3, 5.2, 8.1), `irr` sources chart values and metadata differently when operating on a local chart path versus a Helm release name. A robust abstraction layer is needed to mock these varied data sourcing mechanisms for isolated testing.
+    - **Existing Model:** `docs/FILESYSTEM-MOCKING.MD` details a successful strategy for abstracting filesystem interactions using `afero` and Dependency Injection (DI). This DI approach is the preferred model for the Helm interaction layer.
+    - **Consistency:** The aim is to establish a standard, reusable set of interfaces and mock implementations for Helm interactions, similar to how filesystem interactions are handled, promoting consistency across tests.
+  - **Concept:** Develop a comprehensive mock implementation of a new Helm interaction abstraction layer. This layer will define interfaces for operations like loading chart data (from path or release), fetching release values, and invoking `helm template`.
+  - **Tasks:**
+    - [ ] **Identify External Interactions & Define Interfaces:**
+      - [ ] Systematically review `cmd/irr/inspect.go`, `cmd/irr/override.go`, `cmd/irr/validate.go` and `pkg/helm` to list all direct `helm` CLI calls, Helm SDK usage (e.g., `chartloader`, `action G*etValues`), and Kubernetes API client interactions.
+      - [ ] Define standard Go interfaces (e.g., `ChartLoader`, `ReleaseDataProvider`, or a combined `HelmClientAPI`) in a common package (e.g., `pkg/helmtypes` or within `pkg/helm`) to abstract these operations.
+        - Example `ChartLoader` methods: `LoadValues(source ChartSource) (map[string]interface{}, error)`, `LoadChartMeta(source ChartSource) (*chart.Metadata, error)`
+        - Example `ReleaseDataProvider` methods: `GetReleaseValues(releaseName, namespace string) (map[string]interface{}, error)`
+        - `ChartSource` could be a type to distinguish local path from release identifiers.
+      - [ ] Detail the expected input parameters and return types for each interface method.
+    - [ ] **Create Standard Mock Implementations:**
+      - [ ] Develop reusable mock implementations for these new interfaces, preferably using `testify/mock`. These mocks should reside in a common test utility package (e.g., `pkg/testutil/mocks` or extend `pkg/testutil`).
+      - [ ] Ensure mocks can be configured to simulate various scenarios:
+        - Successful data retrieval (values, chart metadata from path or release).
+        - Errors during data retrieval (file not found, release not found, API errors).
+        - Specific data content for values and chart metadata.
+        - Behavior of `helm template` (success with output, failure with error).
+    - [ ] **Refactor Core `irr` Commands & Service Logic (Primary Focus):**
+      - [ ] Modify the `cmd/irr/` command execution logic (e.g., `runInspect`, `runOverride`, `runValidate`) and any intermediary service layers to accept instances of the new Helm interaction interfaces via Dependency Injection. This is the primary area of refactoring for this phase.
+        - Note: Leverage and adapt the existing `helmAdapterFactory` pattern in `cmd/irr/fileutil.go` for injecting Helm adapter/client instances.
+      - [ ] Update production code paths to pass "real" implementations of these interfaces (e.g., one that uses `afero` and Helm SDKs for file-based charts, another that uses Helm SDKs for release-based operations).
+      - [ ] Ensure unit/component test paths for the `cmd/irr` layer can receive and utilize the mock implementations.
+    - [ ] **Update/Create Unit & Component Tests:**
+      - [ ] Write new unit/component tests for the `cmd/irr` layer, leveraging the injected mocks to verify logic for different data sources and scenarios.
+      - [ ] Review existing unit tests in `pkg/helm`, `pkg/chart` etc. If they directly perform Helm interactions that are now covered by the new interfaces, refactor them to use the standard mocks.
+        - (Note: `pkg/analyzer` and `pkg/generator` tests, which are already data-driven, may not need significant changes as they consume pre-processed data).
+      - [ ] Re-evaluate and potentially revive/refactor tests like those in the commented-out `pkg/chart/rules_integration_test.go` if its `MockChartLoader` aligns with the new standard interfaces.
+    - [ ] **Ensure Mock Configurability:**
+      - [ ] Implement a clear and robust mechanism for configuring the mock client's behavior for each test scenario (e.g., using methods like `mockClient.ExpectGetValues(...).Return(...)`).
+      - [ ] Document how to set up the mock client for common test patterns.
+  - **Pros:**
+    - Complete isolation from external dependencies for core logic tests.
+    - Fastest execution speed for unit/component tests.
+    - Full control over test scenarios for focused testing.
+  - **Cons:**
+    - Significant upfront development effort to create accurate mocks.
+    - Mocks might diverge from actual Helm behavior over time, requiring maintenance.
+    - May not perfectly replicate all nuances of Helm's internal logic for all scenarios.
 
-## Phase 7: Image Pattern Detection Improvements (Revised Focus)
+##### Phase 6.2: Enhanced `helm template` with Value Simulation (CLI/Chart-Path Mode Tests)
+  - **Goal:** Validate `irr`'s behavior when interacting with the `helm template` command, particularly for chart-path based operations (e.g., `irr inspect --chart-path ...`, `irr override --chart-path ...`, `irr validate --chart-path ...`), without requiring a full Kubernetes cluster.
+  - **Scope:** Tests that focus on `irr`'s ability to correctly prepare values for `helm template` and interpret its output/behavior, especially for the `validate` command or when simulating chart processing locally.
+  - **Concept:** Rely primarily on `helm template` for core validation but enhance how `irr` prepares inputs for it, simulating the "deployed state" or complex value scenarios without actual deployment.
+  - **Tasks:**
+    - [ ] For `--chart-path` based operations, instead of (or in addition to) full K8s mocking, focus on constructing the necessary values input for `helm template` by:
+      - Loading the chart's default `values.yaml`.
+      - Simulating the application of user-provided values (e.g., from `-f` flags).
+      - Applying `irr`-generated overrides to these simulated values.
+    - [ ] Develop a robust way to manage and inject these simulated "current values" into the `helm template` process invoked by `irr validate` or other relevant commands.
+    - [ ] Update `TestHarness` and relevant integration tests to set up these simulated value states for `helm template` based tests.
+  - **Pros:**
+    - Leverages Helm's mature templating engine, ensuring accuracy for `helm template` based validation.
+    - Less extensive Go-level mocking code to write for these specific scenarios compared to Option 1.
+    - Good for testing `irr validate` in chart-path mode.
+  - **Cons:**
+    - Still relies on the `helm` binary being present and correctly configured.
+    - Simulating complex Helm value merging logic (e.g., order of `-f` files, `--set` overrides) accurately can be challenging outside a real Helm invocation.
+    - Does not cover plugin-mode interactions requiring a K8s API.
 
-### Overview
-Improve the analyzer's ability to detect and process image references in complex Helm charts, particularly focusing on init containers, admission webhooks, and other specialized configurations.
-
-### Motivation
-- Address missed image references in complex charts (e.g., admission webhooks).
-- Improve reliability via consistent detection and debug tooling.
-
-### Implementation Steps
-
-#### Phase 7.1: Debugging and Analysis [COMPLETED]
-
-#### Phase 7.2: Image Pattern Detection Improvements [COMPLETED]
-## Phase 8: Fix Bitnami Chart Detection and Rules Processing [COMPLETED]
-
-### Implementation Steps
-- [ ] **[P2]** Research & Design Helm Value Computation replication.
-- [ ] **[P2]** Refactor Analyzer Input to accept computed/merged values + origin info.
-- [ ] **[P2]** Adapt Analyzer Traversal & Source Path Logic for subchart context.
-- [ ] **[P2]** Update Command Usage (`inspect`, `override`) to use new logic.
-- [ ] **[P2]** Add Comprehensive Tests for umbrella charts and subchart overrides.
-- [ ] **[P2]** Update Documentation removing subchart limitations.
-- [ ] **[P3]** Review/Remove Warning Mechanism (from Phase 9) if obsolete.
-
-### Acceptance Criteria (Phase 10)
-- `inspect`/`override` handle subchart values/paths correctly. Tests pass. Docs updated. Warning (Phase 9) may be removed.
-
-
-## Phase 11: Decouple Override Validation [COMPLETED]
-- Introduced `--no-validate` flag to `irr override`.
-
-## Phase 12: Enhance Override Robustness for Live Release Value Errors [COMPLETED]
-- Improved handling of problematic strings in live release values, including fallback to default values with a warning.
-
-## Phase 13: Code Documentation Review and Alignment [COMPLETED]
-- Reviewed and aligned Go code documentation with current functionality.
-
-## Phase 14: Add --all-namespaces (-A) Flag to `inspect` [COMPLETED]
-- Added `-A`/`--all-namespaces` and `--overwrite-skeleton` flags to `irr inspect`.
-- Enabled cluster-wide image inspection and skeleton generation.
-
-## Phase 9: Handle Subcharts (Analyzer Enhancement & Generator/Inspector Alignment)
-
-### Overview
-Enhance the analyzer and downstream components (generator, inspector) to correctly process Helm charts with subcharts, ensuring that image definitions from subchart default values are detected and handled correctly. This addresses limitations found with complex umbrella charts like kube-prometheus-stack.
-
-### Motivation
-- The original analyzer only processed top-level `values.yaml`.
-- Images defined only in subchart `values.yaml` files (or other sources merged by Helm) were missed, leading to incomplete `inspect` results and `override` files.
-- Users need accurate analysis and generation for complex charts to create reliable overrides.
-- Integration tests revealed that while the analyzer refactor (Phase 9.3) correctly identified images, the generator and inspector were not correctly handling the resulting paths/structures.
-
-### Implementation Steps
-
-#### Phase 9.1: Implement Discrepancy Warning (User Feedback Stop-Gap) [OBSOLETE]
-- This was a temporary measure before full subchart support.
-
-#### Phase 9.2: Refine Analyzer Context-Driven Image Identification [IN PROGRESS]
-_Objective: Fix over-matching of non-image strings in context-aware analysis (`inspect -A`) by adopting a robust, structurally-aware algorithm, validated by a rigorous testing framework._
-
-**Problem:** The initial context-aware analyzer (Phase 9.3) successfully identified value paths but interpreted too many generic strings (e.g., "IfNotPresent", "Cluster", hook annotations, Prometheus relabel configs) as images. This occurred because `image.ParseImageReference` adds defaults (`docker.io/library/`, `:latest`), making simple strings appear image-like. Blacklist filtering proved brittle.
-
-**Refined Algorithm ("Two-Phase Parsing & Structural Validation"):**
-1.  **Initial Context Check (Optional Optimization):** Use a simplified `isProbableImageKeyPath` helper to quickly identify common image locations (e.g., key is `image`/`repository`, path ends `.image`/`.repository`/`.imageRef`). If false, skip parsing for this path.
-2.  **Basic Validation:** Trim the string value (`trimmedVal`). If empty or starts with `/`, return `nil`.
-3.  **Parse WITHOUT Defaults:** Call `parseImageStringNoDefaults(trimmedVal)` to get `parsedReg`, `parsedRepo`, `parsedTag`.
-4.  **Structural Validation (Core Filter):** Check if the string has inherent image structure: `hasStructure := (parsedReg != "" || strings.Contains(parsedRepo, "/"))`. If `!hasStructure` (it's just a simple word/identifier), **return `nil`**. This is the key step to filter strings that only parse due to defaulting.
-5.  **Parse WITH Defaults:** If structural validation passed, parse *with* defaults: `ref, err := image.ParseImageReference(trimmedVal)`. Handle errors or empty `ref.Repository` by returning `nil`.
-6.  **Minimal Keyword Check:** Reject `trimmedVal` if it matches `true`, `false`, or `null` (case-insensitive).
-7.  **Record Pattern:** If all checks pass, record the `analysis.ImagePattern` using components from the defaulted parse (`ref`) for `Structure` and the original `val` for `Value`.
-
-**Testing Framework & Feedback Loop:**
-1.  **Ground Truth Creation:**
-    *   Select a diverse corpus of charts (10-20+) from `test/chart-cache` and real-world examples.
-    *   Manually annotate values: For each chart (including dependencies), meticulously review `values.yaml` files and create a map `{(chart_name, path): is_image}` marking every path *intended* to hold an image (string or map).
-    *   **Supplementary Validation:** During annotation or analysis, known image name patterns (e.g., `debian`, `alpine`, `nginx` + version tag) can serve as *confidence signals* to help verify the ground truth or evaluate algorithm performance, but these patterns **must not** become the primary detection logic in the algorithm itself.
-2.  **Test Harness Implementation:**
-    *   Create a tool that takes a chart path and two `irr` versions/analyzer functions (e.g., current vs. new algorithm).
-    *   For each algorithm, run `irr inspect --chart-path <chart> -o json` and parse the output.
-    *   Compare identified `imagePatterns[].Path` against the ground truth for that chart.
-    *   Calculate and report metrics: True Positives (TP), False Positives (FP), False Negatives (FN), Precision (TP / (TP + FP)), Recall (TP / (TP + FN)).
-    *   (Optional) Compare `irr` image count against `helm template <chart> | <parse_rendered_image_count>` as a heuristic baseline.
-3.  **Analysis & Refinement:**
-    *   Run the harness across the corpus.
-    *   Compare aggregate Precision/Recall. Aim to significantly increase Precision without decreasing Recall.
-    *   Analyze specific FPs/FNs to identify algorithm weaknesses and refine the logic (e.g., adjust structural validation, minimal keyword check, or `isProbableImageKeyPath`).
-
-**Verification:** Implement the algorithm, build the harness (or manually test on the corpus initially), compare results, and iterate based on Precision/Recall metrics and FP/FN analysis.
-
-**Status:** This refined algorithm and testing plan is the active task to resolve `inspect -A` accuracy issues before proceeding with Phase 9.4.
-
-#### Phase 9.3: Refactor Analyzer for Full Subchart Support (The Correct Fix) [COMPLETED]
-_Objective: Ensure the analyzer can fully replicate Helm's value merging, including subcharts, to enable accurate image path detection._
-
-- [x]   **Phase 9.3.1 - 9.3.10:** Completed tasks related to prototyping Helm value merging, designing context structures, adapting analyzer traversal, implementing chart loading utilities, integrating into commands, identifying test cases, adding unit tests, and updating documentation regarding the *analyzer's* capabilities.
-    - **Outcome:** The analyzer (`internal/helm/context_analyzer.go`) now correctly identifies images and their source paths (e.g., `child.image`) within merged value structures.
-
-#### Phase 9.4: Align Generator and Inspector with Context-Aware Analysis
-_Objective: Ensure the override generator and inspect command correctly process the paths and structures identified by the context-aware analyzer, especially for subchart values, resolving current integration test failures._
-
-**Dependency:** This phase depends on the successful implementation and verification of the refined context-driven analyzer logic in **Phase 9.2**. The analyzer must provide accurate image patterns as input.
-
-**Current Status (Integration Test Failures):**
-- **Parent Chart Tests (`TestOverrideParentChart`, `TestInspectParentChart`):**
-    - `override` generates incorrect repository path prefix for subchart image `another-child.monitoring.prometheusImage` (uses `docker.io/` instead of expected `quayio/`).
-    - `inspect` output format seems incorrect (missing `chart:`, `imagePatterns:`) and identifies the wrong source registry for the same subchart image.
-- **Kube Prometheus Stack Tests (`TestKubePrometheusStack*`):**
-    - Fail validation (`exit 16`) due to `semverCompare` error in `prometheus-node-exporter` subchart template. Suggests incorrect tag override (e.g., missing, empty, or non-semver like `latest`).
-- **Bitnami Chart Tests (`TestComplexChartFeatures/ingress-nginx...`, `TestClickhouseOperator`, `TestRulesSystemIntegration/Bitnami_ValidationSucceeds`):**
-    - Fail validation (`exit 16`) due to Bitnami's internal container validation logic triggered by rewritten image paths. Requires chart-specific flags (e.g., `global.security.allowInsecureImages=true`) during validation, which is outside the scope of Phase 9 and relates to **Phase 10**.
-
-- [ ] **Phase 9.4.1: [P1] Debug & Fix Override Generator (`pkg/chart/generator.go`)**
-    - [x] **Goal:** Resolve failures in context-aware override tests (`TestOverrideParentChart`, `TestCertManager`, `TestOverrideAlias`, `TestOverrideDeepNesting`, `TestOverrideGlobals`).
-    - [x] **Tasks:**
-        - [x] Analyze `panic` and incorrect values in `TestOverrideParentChart` failures. -> **Resolved panic by fixing strategy initialization.**
-        - [x] Debug interaction between context-aware analyzer and generator for `TestOverrideParentChart`: Verified path/registry data flow, fixed generator path/structure creation, fixed registry handling. -> **`TestOverrideParentChart` passing.**
-        - [x] Debug tag handling for `TestKubePrometheusStack*` failures: Verified analyzer tag identification, fixed generator tag logic (incl. AppVersion fallbacks). -> **`TestKubePrometheusStack*` tests passing.**
-        - [x] Fix `global.imageRegistry` handling for `TestOverrideGlobals` -> **`TestOverrideGlobals` now passing.**
-        - [x] Fix `PrefixSourceRegistryStrategy` to handle dots in registry names correctly -> **Added comments explaining the importance of preserving dots for readability.**
-        - [x] Fix special case for `TestRegistryPrefixTransformation` to transform registry names by removing dots when used as path prefixes -> **Registry prefix transformation tests now passing.**
-        - [x] Fix registry mapping loading in `runOverrideStandaloneMode` -> **Registry mapping file tests (`TestRegistryMappingFile`, `TestConfigFileMappings`) now passing.**
-    - [x] **Integration Test Failures (Phase 9.4.1 Continued):**
-      - [x] Fix `TestOverrideParentChart` and `TestInspectParentChart` failures related to incorrect repository path prefix (`docker.io/` vs `quayio/`) and inspect output format/registry detection for subchart images. -> **Fixed strategy path generation and updated outdated test assertions.**
-      - [ ] Fix `TestComplexChartFeatures/ingress-nginx...` failures related to Bitnami validation (Move to Phase 10).
-
-- [x] **Phase 9.5: Implement New Context-Aware Tests** [COMPLETED]
-    - [x] **Goal:** Implement planned tests for aliases, deep nesting, globals interaction.
-    - [x] **Tasks:**
-        - [x] Add `TestOverrideAlias`
-        - [x] Add `TestOverrideDeepNesting`
-        - [x] Add `TestOverrideGlobals`
-        - [x] Add corresponding `TestInspect*` tests (`TestInspectAlias` implemented).
-    - [x] **Next Step:** Tests implemented to verify context-aware functionality with aliases, deep nesting, and globals.
-
-- [ ] **Phase 10: Address Bitnami Validation Failures** [PAUSED]
-    - [ ] **Goal:** Make tests involving Bitnami charts pass their internal validation after IRR overrides.
-    - [ ] **Tasks:**
-        - [ ] Investigate required flags (e.g., `global.security.allowInsecureImages=true`).
-        - [ ] Determine how to pass these flags during the test harness's `helm template` validation step.
-        - [ ] Update test harness or IRR validation logic.
-    - [ ] **Current Status:** Tests like `TestClickhouseOperator` fail due to Bitnami validation rejecting rewritten images.
-    - [ ] **Next Step:** Prioritize after Phase 9.5 tests are added.
-
-- [x] **Phase 10.1: Identify Failing Charts** [COMPLETED]
-    - [x] **Goal:** Compile a definitive list of charts failing `helm template`.
-    - [x] **Tasks:**
-        - [x] Re-run `test/tools/test-charts.py` if necessary to get up-to-date results.
-        - [x] Parse the output log (`test/output/error_details.csv` or similar) generated by `test-charts.py`.
-        - [x] Extract all chart names/versions with template errors and create documentation.
-
-- [ ] **Phase 10.2: Manual Investigation & Minimal Value Set Discovery (Sampling)**
-    - [ ] **Goal:** Understand failure reasons and find minimal `--set` parameters for a sample of failing charts.
-    - [ ] **Tasks:**
-        - [ ] Select a representative sample (e.g., 5-10) of the failing charts identified in 10.1, aiming for variety in chart source and error type if possible.
-        - [ ] For each sampled chart (using its path in `test/chart-cache`):
-            - [ ] Run `helm template <chart_path>` without any extra values. Record the exact error message.
-            - [ ] Analyze the error: consult the chart's `values.yaml`, `README.md`, `NOTES.txt`, and template files (`templates/**.yaml`) referenced in the error.
-            - [ ] Iteratively add necessary values using `--set key=value` (or `--set-string`, `--set-file`
-
-- [ ] **Phase 12: Address inspect no image found
+##### Phase 6.3: Transition to Kind Cluster (Plugin Mode & Full Integration Tests)
+  - **Goal:** Replace the use of external/real Kubernetes clusters in existing integration tests with local, ephemeral Kind (Kubernetes in Docker) clusters. This enables true end-to-end testing of `irr` in plugin mode (e.g., `helm irr inspect <release> -n <ns>`) and other scenarios requiring a live Kubernetes API, but in a controlled, fast, and reproducible environment.
+  - **Scope:** Integration tests that currently interact with a real Kubernetes cluster, especially those testing Helm plugin mode operations that rely on `helm get values`, `helm list`, or other release-aware interactions. The tests identified by `grep -n -H 'namespace :=' test/integration/*.go` are primary candidates for this phase.
+  - **Concept:** Combine elements of using real Helm against a real (but local/disposable) Kubernetes API. Mock Kubernetes API interactions for release discovery and fetching basic metadata, but use `helm template` with simulated values for validation.
+  - **Tasks:**
+    - [ ] Implement mocks for `helm list` and parts of `helm get values` that retrieve release metadata (chart name, version, namespace). (Potentially superseded by direct Kind interaction)
+    - [ ] Use the value simulation approach from Option 2 for preparing inputs to `helm template` within `irr validate`. (Potentially superseded by direct Kind interaction)
+    - [ ] **Setup Kind Integration:**
+      - [ ] Integrate Kind cluster provisioning (e.g., `kind create cluster`) and teardown (`kind delete cluster`) into the `TestHarness` or CI/CD pipeline scripts for integration tests.
+      - [ ] Configure `TestHarness` to obtain and use the Kubeconfig from the temporary Kind cluster for all Helm operations within these tests.
+    - [ ] **Migrate Existing Integration Tests:**
+      - [ ] Systematically refactor existing integration tests (e.g., in `test/integration/override_command_test.go`, `test/integration/inspect_command_test.go`) that install Helm releases to a "real" cluster.
+      - [ ] Modify these tests to:
+        - Ensure a Kind cluster is running.
+        - Install necessary Helm charts (e.g., `fallback-test`, `parent-test`) into the Kind cluster.
+        - Execute `irr` commands (e.g., `helm irr inspect my-release -n test-ns`) targeting the release in the Kind cluster.
+        - Perform assertions based on the output or state.
+        - Ensure Helm releases are uninstalled from Kind after tests.
+    - [ ] **Verify Plugin Behaviors:**
+      - [ ] Confirm that namespace handling, release value fetching, and other plugin-specific features work correctly against the Kind cluster.
+    - [ ] **Update Documentation:**
+      - [ ] Revise `TESTING.md` and any relevant developer guides to document the use of Kind for integration tests, including setup and execution.
+  - **Pros:**
+    - Balances mocking effort with the accuracy of using `helm template`. (Original Pro)
+    - Potentially faster to implement than a full Option 1. (Original Pro)
+    - **Provides high-fidelity testing for plugin mode and K8s interactions.**
+    - **Faster and more reliable than tests against external/shared K8s clusters.**
+    - **Improves CI/CD efficiency and reduces external dependencies.**
+  - **Cons:**
+    - More complex test setup than a pure Option 2. (Original Con)
+    - Still requires careful management of how simulated values interact with the real `helm template`. (Original Con, less relevant if Kind provides the "real" values)
+    - **Adds Kind as a development/CI dependency.**
+    - **Slower than pure Go-level mock tests (Phase 6.1) or `helm template` simulation (Phase 6.2).**

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -295,7 +295,7 @@ The Phase 4 implementation focuses on a standalone CLI with three core commands:
 *   **Inputs:**
     *   `--chart-path <path>` OR `--release-name <name>`
     *   `--target-registry <url>` (required, unless fully defined via mappings)
-    *   `--source-registries <list>` (required, unless using mappings)
+    *   `--source-registries <list>` (Optional. If not provided, source registries are derived from enabled entries in the `registry-file`. If provided, this list explicitly defines which source registries to process, overriding derivation from the `registry-file`.)
     *   Optional: `--output-file <path>` (defaults to stdout)
     *   Optional: `--registry-file <path>` (for registry mappings, exclusions)
     *   Optional: `--strict` (fail on unsupported structures)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "irr"
-version: "0.0.14"
+version: "0.0.15"
 usage: "Inspect, Override, and Validate image references in Helm charts and releases"
 description: |-
   IRR (Image Relocation and Rewrite) is a tool for Helm charts that helps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "registry-rewrite"
-version = "0.0.14"
+version = "0.0.15"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/test-data/charts/deep-nesting-test/templates/deployment.yaml
+++ b/test-data/charts/deep-nesting-test/templates/deployment.yaml
@@ -18,4 +18,4 @@ spec:
         - name: deep-nested
           image: "{{ .Values.level1.level2.level3.level4.level5.image.registry }}/{{ .Values.level1.level2.level3.level4.level5.image.repository }}:{{ .Values.level1.level2.level3.level4.level5.image.tag }}"
         - name: frontend
-          image: "{{ .Values.services.frontend.containers[0].image.registry }}/{{ .Values.services.frontend.containers[0].image.repository }}:{{ .Values.services.frontend.containers[0].image.tag }}" 
+          image: "{{ .Values.services.frontend.primaryContainer.image.registry }}/{{ .Values.services.frontend.primaryContainer.image.repository }}:{{ .Values.services.frontend.primaryContainer.image.tag }}" 

--- a/test-data/charts/deep-nesting-test/values.yaml
+++ b/test-data/charts/deep-nesting-test/values.yaml
@@ -12,6 +12,12 @@ level1:
 # Deeply nested array with image
 services:
   frontend:
+    # Add a primary container that matches the first container in the array
+    primaryContainer:
+      image:
+        registry: quay.io
+        repository: frontend/webapp
+        tag: "stable"
     containers:
       - name: main
         image:

--- a/test/integration/logging_test.go
+++ b/test/integration/logging_test.go
@@ -43,7 +43,7 @@ func TestDefaultLogLevels(t *testing.T) {
 	baseArgs := []string{
 		"override",
 		"--target-registry", "test.registry.io",
-		"--source-registries", "docker.io",
+		"--source-registries", "unmapped.registry.example.com",
 	}
 
 	runLogLevelTest(

--- a/test/integration/registry_test.go
+++ b/test/integration/registry_test.go
@@ -56,8 +56,8 @@ compatibility:
 			mappingContent: `docker.io: registry.example.com/docker
 quay.io: registry.example.com/quay
 `,
-			shouldSucceed:  false,                           // Changed to false because legacy format is no longer supported
-			errorSubstring: "failed to parse mappings file", // Updated error substring
+			shouldSucceed: true,
+			expectedText:  "test.registry.io",
 		},
 		{
 			name: "malformed YAML format",
@@ -87,8 +87,8 @@ registries:
   defaultTarget: registry.example.com/default
   strictMode: false
 `,
-			shouldSucceed:  false,
-			errorSubstring: "failed to parse mappings file", // Updated expected substring
+			shouldSucceed: true,
+			expectedText:  "test.registry.io",
 		},
 	}
 


### PR DESCRIPTION
1.) Auto-derivation of Source Registries: The tool now automatically derives source registries from enabled entries in the registry mappings file when `-source-registries` isn't explicitly provided. This simplifies the user experience by eliminating the need to specify both the mappings file and source registries separately.

2.) Registry Configuration Standardization: Renamed the deprecated `--config` flag to the more descriptive `-registry-file ` flag and improved error messages and documentation around registry configuration.

3.) Path Strategy Improvements: Fixed how registry domains are preserved in repository paths, ensuring the original registry domain (with dots) is maintained rather than using the normalized version.

4.) Empty Mapping Handling: Enhanced the tool's robustness when handling empty or incomplete registry mapping files, particularly in non-strict mode, by avoiding nil pointer issues and providing clearer warnings.

5.) Integration Test Enhancements: Improved the test harness with enhanced registry file handling and adjusted test expectations to align with the new behavior.

6.) Chart Template Fix: Resolved a syntax error in the deep-nesting-test chart by removing array indexing syntax and updating the values structure.

All tests passed:
make lint test test-integration