### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/post-release-install-test.yml
+++ b/.github/workflows/post-release-install-test.yml
@@ -1,4 +1,6 @@
 name: Post-Release Install Test
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/lucas-albers-lz4/irr/security/code-scanning/13](https://github.com/lucas-albers-lz4/irr/security/code-scanning/13)

The best way to fix this problem is to explicitly add a `permissions` block to the workflow YAML. Since the workflow only installs helm and tests a plugin install without using GITHUB_TOKEN for write operations, the minimal safe set of permissions is to set `contents: read`, blocking all write access. This can be added globally at the root level (before `jobs:`), which will apply to all jobs, unless overridden by job-specific permissions. The edit should insert the following block after the workflow `name:` and before `on:` to set global permissions:

```yaml
permissions:
  contents: read
```

No imports or additional definitions are required, just a small change to the YAML file before the jobs section.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
